### PR TITLE
Remove + from version string for better maven support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-  compile('org.apache.commons:commons-collections4:4.1+')
+  compile('org.apache.commons:commons-collections4:4.1')
 
   testCompile('com.miglayout:miglayout-javafx:5.1.1-SNAPSHOT')
   testCompile group: 'junit', name: 'junit', version: '4.12'


### PR DESCRIPTION
While gradle supports version strings with "+" this is not the case for maven. 
If this library is used in a maven project, maven can't find the correct version
for the transitive dependency defined with the + in the version string.

The error message from maven is:
```
[ERROR] Failed to execute goal on project <projectname>: 
Could not resolve dependencies for project <my.project.artifact.id>: 
Failure to find org.apache.commons:commons-collections4:jar:4.1+ in http://repo1.maven.org/maven2 
was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]
```

Here is a stackoverflow threat with the same topic: https://stackoverflow.com/questions/28510856/maven-cannot-resolve-dependency-due-to-plus-sign-in-version
